### PR TITLE
Define in Client class all environment endpoints and by default use production.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ And then install
 ## Usage
 
 ```ruby
-client = Frontgo::Client.new('https://api.frontpayment.no', key: 'your-api-key')
+client = Frontgo::Client.new(key: 'your-api-key') # add demo: true to make calls to non-production instance.
 
 # Create payment session
 client.create_session_for_one_time_payment_link({

--- a/lib/frontgo.rb
+++ b/lib/frontgo.rb
@@ -24,12 +24,40 @@ module Frontgo
     include Terminal
     include Credit
 
-    def initialize(base_url, key:)
+    # Initializes the client.
+    #
+    # @param key [String] Bearer key
+    # @param demo [Boolean] Optionally target the demo environment
+    #
+    # @return [Client] A fully initialized client
+
+    def initialize(key:, demo: false)
+      @demo = demo || false
       @connection = Faraday.new(base_url) do |conn|
         conn.headers["Authorization"] = "Bearer #{key}"
         conn.request :json
         conn.response :json
         conn.response :raise_error
+      end
+    end
+
+    private
+
+    # Checks if the client is using the demo environment
+    #
+    # @return [Boolean]
+    def demo?
+      @demo
+    end
+
+    # Retrieves the base URL to use when making api requests.
+    #
+    # @return [String]
+    def base_url
+      if demo?
+        "https://demo-api.frontpayment.no/api/v1/"
+      else
+        "https://apigo.frontpayment.no/api/v1"
       end
     end
   end

--- a/lib/frontgo/connection.rb
+++ b/lib/frontgo/connection.rb
@@ -18,6 +18,10 @@ module Frontgo
       request :delete, uri, nil, headers
     end
 
+    def url_prefix
+      @connection.url_prefix
+    end
+
     private
 
     def request(method, url, body, headers)

--- a/lib/frontgo/credit.rb
+++ b/lib/frontgo/credit.rb
@@ -14,7 +14,7 @@ module Frontgo
     #     personalId: "ckFXQWJqeFlieE06ZDU3NGJlNTczMGYx"
     #   })
     def credit_check_private(params)
-      post "api/v1/connect/credit/check/private", params
+      post "connect/credit/check/private", params
     end
 
     # @example Credit check for corporate customer
@@ -22,13 +22,13 @@ module Frontgo
     #     organizationId: "998379342"
     #   })
     def credit_check_corporate(params)
-      post "api/v1/connect/credit/check/corporate", params
+      post "connect/credit/check/corporate", params
     end
 
     # @example Get credit check history list
     #   client.get_credit_check_list
     def get_credit_check_list
-      get "api/v1/connect/credit/check/list"
+      get "connect/credit/check/list"
     end
   end
 end

--- a/lib/frontgo/customer.rb
+++ b/lib/frontgo/customer.rb
@@ -6,7 +6,7 @@ module Frontgo
     # @example Get customer details
     #   client.get_customer_details_by_uuid("CSRT1511414842")
     def get_customer_details_by_uuid(uuid)
-      get "api/v1/connect/customers/details/#{uuid}"
+      get "connect/customers/details/#{uuid}"
     end
 
     # @example Update private customer
@@ -33,7 +33,7 @@ module Frontgo
     #     }
     #   })
     def update_private_customer(uuid, params)
-      put "api/v1/connect/customers/update/private/#{uuid}", params
+      put "connect/customers/update/private/#{uuid}", params
     end
 
     # @example Update corporate customer
@@ -70,7 +70,7 @@ module Frontgo
     #     }
     #   })
     def update_corporate_customer(uuid, params)
-      put "api/v1/connect/customers/update/corporate/#{uuid}", params
+      put "connect/customers/update/corporate/#{uuid}", params
     end
   end
 end

--- a/lib/frontgo/order.rb
+++ b/lib/frontgo/order.rb
@@ -12,7 +12,7 @@ module Frontgo
     #     callback: { success: "https://example.com/success", failure: "https://example.com/failure" }
     #   })
     def create_session_for_one_time_payment_link(params)
-      post "api/v1/connect/orders/regular/submit", params
+      post "connect/orders/regular/submit", params
     end
 
     # @example Create an invoice order session
@@ -25,7 +25,7 @@ module Frontgo
     #     separateInvoices: true
     #   })
     def create_session_for_invoice_order(params)
-      post "api/v1/connect/orders/regular/submit", params
+      post "connect/orders/regular/submit", params
     end
 
     # Can be filtered by status type as query (?type=)
@@ -36,19 +36,19 @@ module Frontgo
     # @example Get only invoiced orders
     #   client.get_all_order_status(type: 'invoiced')
     def get_all_order_status(params = {})
-      get "api/v1/connect/orders/status", params
+      get "connect/orders/status", params
     end
 
     # @example Get order status by UUID
     #   client.get_order_status_by_uuid("ODR347888404")
     def get_order_status_by_uuid(uuid)
-      get "api/v1/connect/orders/status/#{uuid}"
+      get "connect/orders/status/#{uuid}"
     end
 
     # @example Get detailed order information
     #   client.get_order_details_by_uuid("ODR986760186")
     def get_order_details_by_uuid(uuid)
-      get "api/v1/connect/orders/details/#{uuid}"
+      get "connect/orders/details/#{uuid}"
     end
 
     # @example Send E-Faktura invoice
@@ -63,7 +63,7 @@ module Frontgo
     #     orderSummary: { subTotal: 51.00, totalTax: 0.00, grandTotal: 51.00 }
     #   })
     def send_e_faktura(params)
-      post "api/v1/connect/orders/invoice/create/faktura", params
+      post "connect/orders/invoice/create/faktura", params
     end
 
     # @example Send EHF invoice for corporate customers
@@ -78,7 +78,7 @@ module Frontgo
     #     orderSummary: { subTotal: 51.00, totalTax: 0.00, grandTotal: 51.00 }
     #   })
     def send_ehf_invoice(params)
-      post "api/v1/connect/orders/invoice/create/ehf", params
+      post "connect/orders/invoice/create/ehf", params
     end
 
     # @example Cancel an order
@@ -86,7 +86,7 @@ module Frontgo
     #     cancellationNote: "Customer requested cancellation"
     #   })
     def cancel_order(order_uuid, params)
-      post "api/v1/connect/orders/cancel/#{order_uuid}", params
+      post "connect/orders/cancel/#{order_uuid}", params
     end
 
     # @example Send payment link to customer
@@ -101,7 +101,7 @@ module Frontgo
     #     orderSummary: { subTotal: 51.00, totalTax: 0.00, grandTotal: 51.00 }
     #   })
     def send_payment_link(params)
-      post "api/v1/connect/orders/payment-link/create", params
+      post "connect/orders/payment-link/create", params
     end
 
     # @example Send regular invoice
@@ -117,7 +117,7 @@ module Frontgo
     #     separateInvoices: true
     #   })
     def send_invoice(params)
-      post "api/v1/connect/orders/invoice/create", params
+      post "connect/orders/invoice/create", params
     end
 
     # @example Resend payment link to customer
@@ -127,7 +127,7 @@ module Frontgo
     #     email: "customer@example.com"
     #   })
     def resend_payment_link(uuid, params)
-      post "api/v1/connect/orders/resend/#{uuid}", params
+      post "connect/orders/resend/#{uuid}", params
     end
 
     # @example Refund an order (full or partial)
@@ -140,13 +140,13 @@ module Frontgo
     #     ]
     #   })
     def refund_order(uuid, params)
-      post "api/v1/connect/orders/refund/#{uuid}", params
+      post "connect/orders/refund/#{uuid}", params
     end
 
     # @example Get invoice number for an order
     #   client.get_invoice_number_by_uuid("ODR2005869234")
     def get_invoice_number_by_uuid(uuid)
-      get "api/v1/connect/orders/invoice-number/#{uuid}"
+      get "connect/orders/invoice-number/#{uuid}"
     end
   end
 end

--- a/lib/frontgo/refund.rb
+++ b/lib/frontgo/refund.rb
@@ -26,7 +26,7 @@ module Frontgo
     #     reference: "CHA3852658817"
     #   })
     def request_refund_approval(order_uuid, params)
-      post "api/v1/orders/refund/request/approval/#{order_uuid}", params
+      post "orders/refund/request/approval/#{order_uuid}", params
     end
   end
 end

--- a/lib/frontgo/reservation.rb
+++ b/lib/frontgo/reservation.rb
@@ -18,13 +18,13 @@ module Frontgo
     #     settings: { isChargePartiallyRefundable: true }
     #   })
     def submit_reservation(params)
-      post "api/v1/connect/reservations/submit", params
+      post "connect/reservations/submit", params
     end
 
     # @example Get reservation details by UUID
     #   client.get_reservation_details_by_uuid("RES3633019929")
     def get_reservation_details_by_uuid(uuid)
-      get "api/v1/connect/reservations/details/#{uuid}"
+      get "connect/reservations/details/#{uuid}"
     end
 
     # @example Cancel a reservation
@@ -32,7 +32,7 @@ module Frontgo
     #     note: "Customer requested cancellation"
     #   })
     def cancel_reservation(uuid, params)
-      post "api/v1/connect/reservations/cancel/#{uuid}", params
+      post "connect/reservations/cancel/#{uuid}", params
     end
 
     # @example Capture funds from a reservation
@@ -45,7 +45,7 @@ module Frontgo
     #     additionalText: "Capture for services rendered"
     #   })
     def capture_reservation(uuid, params)
-      post "api/v1/connect/reservations/capture/#{uuid}", params
+      post "connect/reservations/capture/#{uuid}", params
     end
 
     # @example Charge additional amount from reservation
@@ -62,7 +62,7 @@ module Frontgo
     #     additionalText: "Extra service charge"
     #   })
     def charge_reservation(uuid, params)
-      post "api/v1/connect/reservations/charge/#{uuid}", params
+      post "connect/reservations/charge/#{uuid}", params
     end
 
     # @example Complete a reservation
@@ -70,7 +70,7 @@ module Frontgo
     #     note: "Service completed successfully"
     #   })
     def complete_reservation(uuid, params)
-      post "api/v1/connect/reservations/complete/#{uuid}", params
+      post "connect/reservations/complete/#{uuid}", params
     end
 
     # @example Resend reservation payment link
@@ -80,7 +80,7 @@ module Frontgo
     #     email: "customer@example.com"
     #   })
     def resend_reservation(uuid, params)
-      post "api/v1/connect/reservations/resend/#{uuid}", params
+      post "connect/reservations/resend/#{uuid}", params
     end
 
     # @example Refund a reservation (from captured or charged amounts)
@@ -95,7 +95,7 @@ module Frontgo
     #     reference: "CHA3852658817"
     #   })
     def refund_reservation(uuid, params)
-      post "api/v1/connect/reservations/refund/#{uuid}", params
+      post "connect/reservations/refund/#{uuid}", params
     end
 
     # @example Create reservation session for checkout
@@ -116,7 +116,7 @@ module Frontgo
     #     settings: { isChargePartiallyRefundable: true }
     #   })
     def create_session_for_reservation(params)
-      post "api/v1/connect/reservations/create", params
+      post "connect/reservations/create", params
     end
 
     # @example Get reservation history by time frame
@@ -124,7 +124,7 @@ module Frontgo
     # @example Get last 24 hours (when no timestamps provided, defaults to last 24 hours)
     #   client.get_reservation_history_by_time_frame("", "")
     def get_reservation_history_by_time_frame(start_timestamp, end_timestamp)
-      get "api/v1/connect/reservations/history/#{start_timestamp}/#{end_timestamp}"
+      get "connect/reservations/history/#{start_timestamp}/#{end_timestamp}"
     end
   end
 end

--- a/lib/frontgo/subscription.rb
+++ b/lib/frontgo/subscription.rb
@@ -11,7 +11,7 @@ module Frontgo
     #     customerDetails: { name: "John Doe", email: "john@example.com" }
     #   })
     def create_subscription(params)
-      post "api/v1/connect/subscription/submit", params
+      post "connect/subscription/submit", params
     end
 
     # @example Create subscription session for checkout
@@ -22,7 +22,7 @@ module Frontgo
     #     callback: { success: "https://example.com/success", failure: "https://example.com/failure" }
     #   })
     def create_session_for_subscription_payment(params)
-      post "api/v1/connect/subscription/create", params
+      post "connect/subscription/create", params
     end
 
     # @example Get all subscriptions
@@ -32,7 +32,7 @@ module Frontgo
     # @example Filter by phone and date range
     #   client.get_subscription_list(nil, { phone: '+47123456789', startDate: '2023-01-01', endDate: '2023-12-31' })
     def get_subscription_list(status = nil, params = {})
-      endpoint = status ? "api/v1/connect/subscriptions/list/#{status}" : "api/v1/connect/subscriptions/list"
+      endpoint = status ? "connect/subscriptions/list/#{status}" : "connect/subscriptions/list"
       get endpoint, params
     end
 
@@ -43,20 +43,20 @@ module Frontgo
     # @example Filter by subscription UUID
     #   client.get_failed_payment_list(nil, { subscriptionUuid: 'SUB123456789' })
     def get_failed_payment_list(status = nil, params = {})
-      endpoint = status ? "api/v1/connect/subscriptions/failed/list/#{status}" : "api/v1/connect/subscriptions/failed/list"
+      endpoint = status ? "connect/subscriptions/failed/list/#{status}" : "connect/subscriptions/failed/list"
       get endpoint, params
     end
 
     # @example Get subscription details
     #   client.get_subscription_details_by_uuid('SUB123456789')
     def get_subscription_details_by_uuid(uuid)
-      get "api/v1/connect/subscriptions/details/#{uuid}"
+      get "connect/subscriptions/details/#{uuid}"
     end
 
     # @example Get failed payment details
     #   client.get_failed_payment_details('ODR123456789')
     def get_failed_payment_details(order_uuid)
-      get "api/v1/connect/subscriptions/failed/details/#{order_uuid}"
+      get "connect/subscriptions/failed/details/#{order_uuid}"
     end
 
     # @example Resend subscription payment link
@@ -67,13 +67,13 @@ module Frontgo
     #     email: 'customer@example.com'
     #   })
     def resend_subscription(uuid, params)
-      post "api/v1/connect/subscriptions/resend/#{uuid}", params
+      post "connect/subscriptions/resend/#{uuid}", params
     end
 
     # @example Cancel subscription
     #   client.cancel_subscription('SUB123456789', { note: 'Customer requested cancellation' })
     def cancel_subscription(uuid, params)
-      post "api/v1/connect/subscriptions/cancel/#{uuid}", params
+      post "connect/subscriptions/cancel/#{uuid}", params
     end
 
     # @example Refund specific subscription cycles
@@ -82,7 +82,7 @@ module Frontgo
     #     amount: 200.00
     #   })
     def refund_subscription_cycle(uuid, params)
-      post "api/v1/connect/subscriptions/cycles/refund/#{uuid}", params
+      post "connect/subscriptions/cycles/refund/#{uuid}", params
     end
   end
 end

--- a/lib/frontgo/terminal.rb
+++ b/lib/frontgo/terminal.rb
@@ -6,7 +6,7 @@ module Frontgo
     # @example Get terminal lists for organization
     #   client.get_terminal_lists("ORG2074299506")
     def get_terminal_lists(organization_uuid)
-      get "api/v1/connect/terminal/lists/#{organization_uuid}"
+      get "connect/terminal/lists/#{organization_uuid}"
     end
 
     # @example Create terminal order with callback
@@ -29,25 +29,25 @@ module Frontgo
     #     callbackUrl: "https://example-callback.com"
     #   })
     def create_terminal_order(params)
-      post "api/v1/connect/terminal/orders/create", params
+      post "connect/terminal/orders/create", params
     end
 
     # @example Cancel terminal order payment
     #   client.cancel_terminal_order("ODR123456789", { type: "payment" })
     def cancel_terminal_order(order_uuid, params)
-      post "api/v1/connect/terminal/orders/cancel/#{order_uuid}", params
+      post "connect/terminal/orders/cancel/#{order_uuid}", params
     end
 
     # @example Resend terminal order to terminal
     #   client.resend_terminal_order("ODR123456789")
     def resend_terminal_order(order_uuid)
-      post "api/v1/connect/terminal/orders/resend/#{order_uuid}", {}
+      post "connect/terminal/orders/resend/#{order_uuid}", {}
     end
 
     # @example Check payment status
     #   client.get_payment_status("ODR123456789")
     def get_payment_status(order_uuid)
-      get "api/v1/connect/terminal/orders/payment-status/#{order_uuid}"
+      get "connect/terminal/orders/payment-status/#{order_uuid}"
     end
 
     # @example Refund terminal order
@@ -65,19 +65,19 @@ module Frontgo
     #     isReversal: true
     #   })
     def refund_terminal_order(order_uuid, params)
-      post "api/v1/connect/terminal/orders/refund/#{order_uuid}", params
+      post "connect/terminal/orders/refund/#{order_uuid}", params
     end
 
     # @example Check refund status
     #   client.get_refund_status("ODR123456789")
     def get_refund_status(order_uuid)
-      get "api/v1/connect/terminal/orders/refund-status/#{order_uuid}"
+      get "connect/terminal/orders/refund-status/#{order_uuid}"
     end
 
     # @example Cancel refund request
     #   client.cancel_refund_request("ODR123456789", { type: "refund" })
     def cancel_refund_request(order_uuid, params)
-      post "api/v1/connect/terminal/orders/cancel/#{order_uuid}", params
+      post "connect/terminal/orders/cancel/#{order_uuid}", params
     end
   end
 end

--- a/test/test_frontgo.rb
+++ b/test/test_frontgo.rb
@@ -93,11 +93,28 @@ class TestFrontgo < Minitest::Test
     end
   end
 
+  def test_demo_base_url
+    demo_client = Frontgo::Client.new(key: client_key, demo: true)
+    assert_equal "https://demo-api.frontpayment.no/api/v1/", demo_client.url_prefix.to_s
+  end
+
+  def test_production_base_url
+    prod_client = Frontgo::Client.new(key: client_key, demo: false)
+    assert_equal "https://apigo.frontpayment.no/api/v1", prod_client.url_prefix.to_s
+  end
+
+  def test_default_base_url
+    default_client = Frontgo::Client.new(key: client_key)
+    assert_equal "https://apigo.frontpayment.no/api/v1", default_client.url_prefix.to_s
+  end
+
   private
 
   def client
-    @client ||= Frontgo::Client.new(
-      "https://demo-api.frontpayment.no/", key: ENV["FRONTGO_API_KEY"] || "key"
-    )
+    @client ||= Frontgo::Client.new(key: client_key, demo: true)
+  end
+
+  def client_key
+    ENV["FRONTGO_API_KEY"] || "key"
   end
 end


### PR DESCRIPTION
fixes #2 

I'm only aware of two possible instances with front-go and that's `demo`/`production`. Hence, Client will expose the `demo:` attribute in the initialization method with default value `false`.

By default, the client connects to the production instance. If `demo: true` is passed to the initializer we will use a demo instance. 

Example:
```ruby
Frontgo::Client.new(key: ENV["FRONTGO_API_KEY"] , demo: true)
```

## Done
- Define Client.base_url method that will give out predefined instance urls. 
- This change also allows us to define common url paths in base_url, remove repetition from othet modules


## TODO
- [x] Clarify production base url.