### PR TITLE
Don't raise on API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Stop raising on API HTTP errors (4xx/5xx)
+
 ## [0.2.0] - 2024-12-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Stop raising on API HTTP errors (4xx/5xx)
 
-## [0.2.0] - 2024-12-19
+## [0.2.0]
 
 ### Added
 - Support for multiple FrontPayment API environments (production and demo)
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default environment is now production (`https://apigo.frontpayment.no/api/v1`)
 - Demo environment available at `https://demo-api.frontpayment.no/api/v1/` when `demo: true` is passed
 
-## [0.1.1] - 2024-12-19
+## [0.1.1]
 
 ### Added
 - Test coverage for `Order.get_order_status_by_uuid` method
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All Standard Ruby style guide violations
 - Class naming conventions - renamed to singular form for better Ruby conventions
 
-## [0.1.0] - 2024-12-19
+## [0.1.0]
 
 ### Added
 - Initial release of the Frontgo gem

--- a/README.md
+++ b/README.md
@@ -29,8 +29,21 @@ client.create_session_for_one_time_payment_link({
 
 # Get order status
 client.get_order_status_by_uuid("ODR123456789")
-```
 
+# With all the recommended error handling
+begin
+  response = client.get_order_status_by_uuid("ODR123")
+  if response.success?
+    # handle success
+  else
+    # handle non-2xx response
+  end
+rescue Faraday::TimeoutError, Faraday::ConnectionFailed, Faraday::SSLError => e
+  warn "Network error: #{e.class}: #{e.message}"
+rescue Faraday::ParsingError => e
+  warn "Parsing error: #{e.message}"
+end
+```
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/frontgo.rb
+++ b/lib/frontgo.rb
@@ -37,7 +37,6 @@ module Frontgo
         conn.headers["Authorization"] = "Bearer #{key}"
         conn.request :json
         conn.response :json
-        conn.response :raise_error
       end
     end
 


### PR DESCRIPTION
After implementing #6, I understood that it's easier just not to raise errors. Then to have all the excessive error-handling logic.

Let's keep logic thin, and just stop raising errors.

## TODO
- [x] Remove raise error faraday middleware out of the stack
- [ ] Codify error handling logic into testsuit
- [x] Document error handling logic in README.md
- [x] Add it to changelog